### PR TITLE
Refactor chat polling

### DIFF
--- a/Configuration.js.sample
+++ b/Configuration.js.sample
@@ -8,10 +8,11 @@ module.exports = {
         userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) Jinx/0.1.0'
     },
     atlas: {
+        admins: {},
         host: '',
         password: '',
+        poll: 5000,
         ports: [],
-        admins: {}
     },
     commandPrefix: '!',
     discord: {

--- a/js/commands/atlasChatSend.js
+++ b/js/commands/atlasChatSend.js
@@ -2,10 +2,9 @@
 @module commands/atlasChatSend
 */
 import config from '../../Configuration';
+import SRC from 'source-rcon-client';
 
-const SRC = require('source-rcon-client').default, // SRC
-    rconCommand = 'chat', // The command to run
-    atlasServer = config.atlas,
+const atlasServer = config.atlas,
     atlasChatSend = {
         /**
         @property {String} description

--- a/js/commands/atlasChatSend.js
+++ b/js/commands/atlasChatSend.js
@@ -2,6 +2,7 @@
 @module commands/atlasChatSend
 */
 import config from '../../Configuration';
+import presage from 'presage';
 import SRC from 'source-rcon-client';
 
 const atlasServer = config.atlas,
@@ -21,24 +22,55 @@ const atlasServer = config.atlas,
         process: (jinx, message, payload) => new Promise((resolve, reject) => {
             // Collect message metadata for reuse by command logging
             const author = message.author.tag,
-                authorId = message.author.id,
+                // authorId = message.author.id, // This isn't being used. What is it for?
                 channel = message.channel ?
                     message.channel.name :
                     null,
                 command = 'atlasChatSend',
+                rconCommand = `serverchat ${author}: ${payload}`,
                 server = message.guild ?
                     message.guild.name :
                     null;
 
-            atlasServer.ports.forEach(currentPort => {
-                // Create a new client for this host/port combination
-                const client = new SRC(atlasServer.host, currentPort, atlasServer.password),
-                    rconCommand = `serverchat ${message.author.tag}: ${message.content.slice(4)}} \n`;
+            presage.parallel(atlasServer.ports.reduce((portsMap, port) => {
+                if (!portsMap[port]) {
+                    portsMap[port] = () => new Promise(resolve => {
+                        const client = new SRC(atlasServer.host, port, atlasServer.password);
 
-                client.connect()
-                    .then(() => client.send(rconCommand))
-                    .then(response => {
-                        if (response !== 'Server received, But no response!! \n ') {
+                        client.connect().then(() => client.send(rconCommand)).then(response => {
+                            if (response === 'Server received, But no response!! \n ') {
+                                // Send was successful
+                                jinx._commandLog.command('atlasChatSendRelay', {
+                                    author,
+                                    channel,
+                                    command,
+                                    details: {
+                                        payload
+                                    },
+                                    message: message.content,
+                                    server
+                                });
+                            } else {
+                                jinx._commandLog.command('atlasChatSendError', {
+                                    author,
+                                    channel,
+                                    command,
+                                    details: {
+                                        payload
+                                    },
+                                    message: message.content,
+                                    server
+                                });
+                            }
+
+                            /*
+                            We always have to disconnect when we're done
+                            with a connection, success or failure.
+                            */
+                            return client.disconnect();
+                        }).then(() => {
+                            resolve('success');
+                        }).catch(error => {
                             jinx._commandLog.command('atlasChatSendError', {
                                 author,
                                 channel,
@@ -46,28 +78,42 @@ const atlasServer = config.atlas,
                                 details: {
                                     payload
                                 },
+                                error,
                                 message: message.content,
                                 server
                             });
-                            return;
-                        }
 
-                        // Send was successful
-                        jinx._commandLog.command('atlasChatSendRelay', {
-                            author,
-                            channel,
-                            command,
-                            details: {
-                                payload
-                            },
-                            message: message.content,
-                            server
+                            resolve('failure');
                         });
-                    }).catch(reject);
-            });
+                    });
+                }
 
-            // Regardless of what happens, fulfill the Promise so Jinx keeps going.
-            resolve();
+                return portsMap;
+            }, {})).then(results => {
+                jinx._commandLog.command('atlasChatSendFinish', {
+                    author,
+                    channel,
+                    command,
+                    details: {
+                        payload
+                    },
+                    results,
+                    server
+                });
+                resolve();
+            }).catch(error => {
+                jinx._commandLog.command('atlasPollError', {
+                    author,
+                    channel,
+                    command,
+                    details: {
+                        payload
+                    },
+                    error,
+                    server
+                });
+                reject(error);
+            });
         })
     };
 

--- a/js/commands/atlasChatStart.js
+++ b/js/commands/atlasChatStart.js
@@ -20,15 +20,9 @@ const rconCommand = 'getchat', // The command to run
         @returns {Promise<Discord.Message>}
         */
         process: (jinx, message) => new Promise((resolve, reject) => {
-            // Check to see if the user is authorized
-            if (atlasServer.admins[Number(message.author.id)]) {
-                message.channel.send(`Sorry, <@${message.author.id}>. Access Denied`);
-                resolve();
-                return;
-            }
-
-            // Collect message metadata for reuse by command logging;
+            // Collect message metadata for reuse by command logging
             const author = message.author.tag,
+                authorId = message.author.id,
                 channel = message.channel ?
                     message.channel.name :
                     null,
@@ -36,6 +30,13 @@ const rconCommand = 'getchat', // The command to run
                 server = message.guild ?
                     message.guild.name :
                     null;
+
+            // Check to see if the user is authorized
+            if (atlasServer.admins[Number(authorId)]) {
+                message.channel.send(`Sorry, <@${authorId}>. Access Denied.`);
+                resolve();
+                return;
+            }
 
             if (jinx._atlasGetChat) {
                 // If the chat poll is already running, do nothing.

--- a/js/commands/atlasChatStart.js
+++ b/js/commands/atlasChatStart.js
@@ -131,7 +131,7 @@ const SRC = require('source-rcon-client').default, // SRC
                         });
                         jinx._atlasGetChatIsRunning = false;
                     });
-                }, 5000);
+                }, atlasServer.poll);
 
                 // Regardless of what happens, fulfill the Promise so Jinx keeps going.
                 resolve(newMessage);

--- a/js/commands/atlasListPlayers.js
+++ b/js/commands/atlasListPlayers.js
@@ -2,9 +2,9 @@
 @module commands/atlasListPlayers
 */
 import config from '../../Configuration';
+import SRC from 'source-rcon-client';
 
-const SRC = require('source-rcon-client').default, // SRC
-    rconCommand = 'listplayers', // The command to run
+const rconCommand = 'listplayers', // The command to run
     atlasServer = config.atlas,
     atlasListPlayers = {
         /**


### PR DESCRIPTION
- Using [presage's parallel task runner](https://github.com/dsibilly/presage#parallel), we can collect data on all possible Atlas grid squares at once and in a single result variable. This lets us log success or failure once per cycle, and not block on a misbehaving server or malformed response.
- Adds a new bot-level flag called `jinx._atlasGetChatIsRunning`. This is used to effectively lock the polling until the current poll cycle is complete, just in case network conditions or other issues prevent a poll from completing within the 5s timeout.
- Moves the chat poll timeout to `config.atlas.poll` instead of leaving it hardcoded in the atlasChatStart command. The default value is 5s.
- Reordered config properties to be alphabetical in Configuration.js.sample.

**NOTE:** This commit updates the expected `Configuration.js` properties and will require an update to that file in an existing installation.